### PR TITLE
fix: unexpected `yarn install`

### DIFF
--- a/lib/installPackages.js
+++ b/lib/installPackages.js
@@ -35,7 +35,7 @@ module.exports = async ({
   const packageName = packages ? packages.join(', ') : 'packages'
 
   return new Promise((resolve, reject) => {
-    const args = [packages ? 'add' : 'install'].concat(packages ? packages : [])
+    const args = [npmClient === 'yarn' ? 'add' : 'install'].concat(packages ? packages : [])
     if (saveDev) {
       args.push(npmClient === 'npm' ? '-D' : '--dev')
     }

--- a/lib/installPackages.js
+++ b/lib/installPackages.js
@@ -35,7 +35,9 @@ module.exports = async ({
   const packageName = packages ? packages.join(', ') : 'packages'
 
   return new Promise((resolve, reject) => {
-    const args = [npmClient === 'yarn' ? 'add' : 'install'].concat(packages ? packages : [])
+    const args = [npmClient === 'yarn' ? 'add' : 'install'].concat(
+      packages ? packages : []
+    )
     if (saveDev) {
       args.push(npmClient === 'npm' ? '-D' : '--dev')
     }


### PR DESCRIPTION
error `install` has been replaced with `add` to add new dependencies. Run "yarn add install" instead.