### PR TITLE
fix: check if we are already inside git repo before initGit

### DIFF
--- a/lib/GeneratorContext.js
+++ b/lib/GeneratorContext.js
@@ -44,7 +44,21 @@ module.exports = class GeneratorContext {
     return require('./installPackages').getNpmClient()
   }
 
+  isInsideGitRepo() {
+    const ps = spawn.sync('git', ['rev-parse', '--git-dir'], {
+      stdio: 'ignore',
+      cwd: this.outDir
+    })
+    return ps.status === 0
+  }
+
   gitInit() {
+    if (this.isInsideGitRepo()) {
+      logger.info(
+        'Initialization of Git repo ignored because we are inside a Git repo right now'
+      )
+      return
+    }
     const ps = spawn.sync('git', ['init'], {
       stdio: 'ignore',
       cwd: this.outDir


### PR DESCRIPTION
If we are inside a git repo, running `initGit` will create a new git repo inside the main git repo. in this change, we check if we are inside a git repo and ignore "init git repo" step in needed