### PR TITLE
Display a list of cached generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+package-lock.json

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -57,7 +57,7 @@ cli
       const outputPrompt = {
         type: 'input',
         name: 'outDir',
-        message: 'File path to template output',
+        message: 'Output project to (file path):',
         default: '.'
       }
       inquirer.prompt([generatorPrompt, outputPrompt]).then(answers => {
@@ -65,11 +65,12 @@ cli
         const options = {
           generator,
           outDir,
+          updateCheck: true,
           ...flags
         }
         return runGenerator(options)
       })
-    } else {
+    } else if (generator) {
       const options = Object.assign(
         {
           generator,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,11 +6,6 @@ const store = require('../lib/store')
 
 const cli = cac('sao')
 
-// maybe hide this behind a debug flag??
-// cli.command('show', 'Show the config').action(flags => {
-//   console.log(JSON.stringify(store.get(), null, 2))
-// })
-
 cli
   .command('[generator] [outDir]', 'Run a generator')
   .action((generator, outDir, flags) => {


### PR DESCRIPTION
This PR will add a feature that will display a list of cached generators for you to run if you run `sao` with no arguments:

![sao-demo-2](https://user-images.githubusercontent.com/9515/68910103-4403dc00-0716-11ea-99e9-0af5936ebfc1.gif)
