### PR TITLE
fix: allow folders to be removed

### DIFF
--- a/lib/runActions.js
+++ b/lib/runActions.js
@@ -146,7 +146,8 @@ module.exports = async (config, context) => {
       }
       const files = await glob(patterns, {
         cwd: context.outDir,
-        absolute: true
+        absolute: true,
+        onlyFiles: false
       })
       await Promise.all(
         files.map(file => {


### PR DESCRIPTION
This PR allows to remove folders when using the `remove` action. 

The `glob(pattern, options)` method has now the same options for both the `move` and `remove` actions.