### PR TITLE
fix: add support for saofile.mjs

### DIFF
--- a/src/generator-config.ts
+++ b/src/generator-config.ts
@@ -4,7 +4,7 @@ import { PromptOptions } from './utils/prompt'
 import { SAO } from './'
 
 const joycon = new JoyCon({
-  files: ['saofile.js', 'saofile.json'],
+  files: ['saofile.js', 'saofile.mjs', 'saofile.json'],
 })
 
 export interface AddAction {


### PR DESCRIPTION
This PR aims to recognize files with the `.mjs` extension (es modules) as valid alternatives for `saofile`